### PR TITLE
Apply some best practices to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS busybox-min
+FROM --platform=$BUILDPLATFORM alpine:3 AS busybox-min
 
-RUN apk add --update --no-cache wget curl make git libc-dev bash gcc linux-headers eudev-dev
+RUN apk add --no-cache \
+  bash \
+  curl \
+  eudev-dev \
+  gcc \
+  git \
+  libc-dev \
+  linux-headers \
+  make \
+  wget
 
 ARG TARGETARCH
 ARG BUILDARCH
@@ -39,7 +48,13 @@ FROM boxboat/config-merge:latest as config-merge
 
 FROM golang:1.19-alpine
 
-RUN apk add wget curl lz4 nano jq npm
+RUN apk add --no-cache \
+  curl \
+  jq \
+  lz4 \
+  nano \
+  npm \
+  wget
 
 # Install busybox
 COPY --from=busybox-min /busybox/busybox /busybox/busybox
@@ -49,11 +64,16 @@ COPY --from=config-merge /usr/local/config-merge /usr/local/config-merge
 COPY --from=config-merge /usr/local/bin/config-merge /usr/local/bin/config-merge
 COPY --from=config-merge /usr/local/bin/envsubst /usr/local/bin/envsubst
 
-# Add dasel
+# Add dasel.
+# The dasel repository does not post checksums of the published binaries,
+# so use hardcoded binaries in order to avoid potential supply chain attacks.
+# Note, dasel does publish docker images, but only for amd64,
+# so we cannot copy the binary out like we do for config-merge.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-      ARCH=arm64; \
+      ARCH=arm64 DASELSUM="8e1f95b5f361f68ed8376d5a9593ae4249e28153a05b26f1f99f9466efeac5c9  /usr/local/bin/dasel"; \
     else \
-      ARCH=amd64; \
+      ARCH=amd64 DASELSUM="3efd202a525c43c027bddc770861dd637ec8389a4ca3ef2951da7165350219ed  /usr/local/bin/dasel"; \
     fi; \
-    wget -O /usr/local/bin/dasel https://github.com/TomWright/dasel/releases/download/v1.26.0/dasel_linux_$ARCH
-RUN chmod +x /usr/local/bin/dasel
+    wget -O /usr/local/bin/dasel https://github.com/TomWright/dasel/releases/download/v1.26.0/dasel_linux_$ARCH && \
+      sha256sum -c <(echo "$DASELSUM") && \
+      chmod +x /usr/local/bin/dasel


### PR DESCRIPTION
Use alpine image instead of golang for earliest stage, which did not use anything from the golang image.

Use apk add --no-cache per convention inside Dockerfiles, which does not store apk's package cache on disk. This reduced the final image size by about 3MB.

Move apk add package arguments to their own lines, so that diffs are trivial to follow as individual packages are added or removed.

Validate checksum of downloaded dasel binary, to avoid a potential supply chain attack.

Further possible improvements:

- Validate checksum of musl download
- Maybe point at a fixed tag of boxboat/config-merge
- Maybe download gzipped dasel binaries instead of raw binaries
- Update to newer point release of dasel
- Unify the two Dockerfiles by a top-level build arg to switch between the alternative "busybox-min" stages
