### PR TITLE
Add gnu tar from alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN apk add --no-cache \
   nano \
   npm \
   rsync \
+  tar \
   wget \
   zstd-dev
 

--- a/native.Dockerfile
+++ b/native.Dockerfile
@@ -42,6 +42,7 @@ RUN apk add --no-cache \
   nano \
   npm \
   rsync \
+  tar \
   wget \
   zstd-dev
 


### PR DESCRIPTION
This is for better performance with large archives and optimized memory usage compared to the stripped down busybox tar.

This would resolve this issue we're seeing. https://github.com/strangelove-ventures/cosmos-operator/issues/436

This overwrites the `/bin/tar -> /bin/busybox` symlink.