### PR TITLE
feat: add aria2c utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /
 RUN git clone --recursive -b jq-1.6 --single-branch https://github.com/stedolan/jq.git
 WORKDIR /jq
 RUN autoreconf -fi;\
-  ./configure --with-oniguruma=builtin;\ 
+  ./configure --with-oniguruma=builtin;\
   make LDFLAGS=-all-static
 
 FROM boxboat/config-merge:0.2.1 as config-merge
@@ -66,11 +66,12 @@ RUN apk add --no-cache \
   lz4 \
   nano \
   npm \
-  procps \ 
+  procps \
   rsync \
   tar \
   wget \
-  zstd-dev
+  zstd-dev \
+  aria2
 
 # Install busybox
 COPY --from=build-env /busybox/busybox /busybox/busybox

--- a/native.Dockerfile
+++ b/native.Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /
 RUN git clone --recursive -b jq-1.6 --single-branch https://github.com/stedolan/jq.git
 WORKDIR /jq
 RUN autoreconf -fi;\
-  ./configure --with-oniguruma=builtin;\ 
+  ./configure --with-oniguruma=builtin;\
   make LDFLAGS=-all-static
 
 FROM boxboat/config-merge:latest as config-merge
@@ -44,7 +44,8 @@ RUN apk add --no-cache \
   rsync \
   tar \
   wget \
-  zstd-dev
+  zstd-dev \
+  aria2
 
 # Install busybox
 COPY --from=build-env /busybox/busybox /busybox/busybox


### PR DESCRIPTION
This PR is for adding aria2c utility to the infra-toolkit image for faster snapshot downloads

Ref: https://github.com/strangelove-ventures/infra-toolkit/issues/18

## Changes:
- Install aria2c (download utility that supports HTTP and FTP) to speed up snapshot downloading

## Tests
- aria2c installed successfully 
<img width="999" alt="image" src="https://github.com/user-attachments/assets/4deb04c3-a475-4e4c-8cf6-7340eed3c849" />
