### PR TITLE
fix: add zstd and unzip packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ FROM boxboat/config-merge:0.2.1 as config-merge
 FROM alpine:3
 
 RUN apk add --no-cache \
+  aria2 \
   curl \
   lz4 \
   nano \
@@ -69,9 +70,9 @@ RUN apk add --no-cache \
   procps \
   rsync \
   tar \
+  unzip \
   wget \
-  zstd-dev \
-  aria2
+  zstd
 
 # Install busybox
 COPY --from=build-env /busybox/busybox /busybox/busybox


### PR DESCRIPTION
This pr make infra-toolkit installs zstd, unzip, aria2 for more flexibility.